### PR TITLE
Make ipfs-lite WASM compatible

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,6 +14,8 @@ jobs:
       GO111MODULE: on
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,6 +26,9 @@ jobs:
     - name: Build
       run: go build -v ./...
 
+    - name: Build WASM
+      run: GOOS=js GOARCH=wasm go build -v ./...
+
     - name: Test
       run: go test -v -race -coverprofile=coverage.txt -covermode=atomic
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@
 </p>
 
 [![Build Status](https://github.com/hsanjuan/ipfs-lite/actions/workflows/go.yml/badge.svg)](https://github.com/hsanjuan/ipfs-lite/actions/workflows/go.yml)
-[![Godoc](https://godoc.org/github.com/hsanjuan/ipfs-lite?status.svg)](http://godoc.org/github.com/hsanjuan/ipfs-lite)
+[![Go Reference](https://pkg.go.dev/badge/github.com/hsanjuan/ipfs-lite.svg)](https://pkg.go.dev/github.com/hsanjuan/ipfs-lite)
 
 IPFS-Lite is an embeddable, lightweight IPFS peer which runs the minimal setup
-to provide an `ipld.DAGService`. It can:
+to provide an `ipld.DAGService` and UnixFS-files addition and retrieval.
+
+IPFS-Lite can be compiled to WASM and run in the browser.
+
+It can:
 
 * Add, Get, Remove IPLD Nodes to/from the IPFS Network (remove is a local blockstore operation).
 * Add single files (chunk, build the DAG and Add) from a `io.Reader`.
@@ -16,18 +20,18 @@ to provide an `ipld.DAGService`. It can:
 
 It needs:
 
-* A [libp2p Host](https://godoc.org/github.com/libp2p/go-libp2p#New)
-* A [libp2p DHT](https://godoc.org/github.com/libp2p/go-libp2p-kad-dht#New)
-* A [datastore](https://godoc.org/github.com/ipfs/go-datastore) like [BadgerDB](https://godoc.org/github.com/ipfs/go-ds-badger)
+* A [libp2p Host](https://pkg.go.dev/github.com/libp2p/go-libp2p#New)
+* A [libp2p DHT](https://pkg.go.dev/github.com/libp2p/go-libp2p-kad-dht#New)
+* A [datastore](https://pkg.go.dev/github.com/ipfs/go-datastore), such as [BadgerDB](https://pkg.go.dev/github.com/ipfs/go-ds-badger), [go-ds-flatfs](https://pkg.go.dev/github.com/ipfs/go-ds-flatfs) or an [in-memory](https://pkg.go.dev/github.com/hsanjuan/ipfs-lite#NewInMemoryDatastore) one.
 
 Some helper functions are provided to
-[initialize these quickly](https://godoc.org/github.com/hsanjuan/ipfs-lite#SetupLibp2p).
+[initialize these quickly](https://pkg.go.dev/github.com/hsanjuan/ipfs-lite#SetupLibp2p).
 
 It provides:
 
-* An [`ipld.DAGService`](https://godoc.org/github.com/ipfs/go-ipld-format#DAGService)
-* An [`AddFile` method](https://godoc.org/github.com/hsanjuan/ipfs-lite#Peer.AddFile) to add content from a reader
-* A [`GetFile` method](https://godoc.org/github.com/hsanjuan/ipfs-lite#Peer.GetFile) to get a file from IPFS.
+* An [`ipld.DAGService`](https://pkg.go.dev/github.com/ipfs/go-ipld-format#DAGService).
+* An [`AddFile` method](https://pkg.go.dev/github.com/hsanjuan/ipfs-lite#Peer.AddFile) to add content from a reader.
+* A [`GetFile` method](https://pkg.go.dev/github.com/hsanjuan/ipfs-lite#Peer.GetFile) to get a file from IPFS.
 
 The goal of IPFS-Lite is to run the **bare minimal** functionality for any
 IPLD-based application to interact with the IPFS Network by getting and

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,12 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto    # the required coverage value
+        threshold: 10%  # the leniency in hitting the target
+        informational: true
+      patch:
+        default:
+          informational: true
+
+comment: false

--- a/examples/litepeer/litepeer.go
+++ b/examples/litepeer/litepeer.go
@@ -18,10 +18,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ds, err := ipfslite.BadgerDatastore("test")
-	if err != nil {
-		panic(err)
-	}
+	ds := ipfslite.NewInMemoryDatastore()
 	priv, _, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	if err != nil {
 		panic(err)

--- a/examples/walker/walker.go
+++ b/examples/walker/walker.go
@@ -23,10 +23,7 @@ func main() {
 
 	log.SetLogLevel("*", "warn")
 
-	ds, err := ipfslite.BadgerDatastore("test")
-	if err != nil {
-		panic(err)
-	}
+	ds := ipfslite.NewInMemoryDatastore()
 	priv, _, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	if err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/ipfs/go-blockservice v0.1.4
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.4.5
-	github.com/ipfs/go-ds-badger v0.2.6
 	github.com/ipfs/go-ipfs-blockstore v1.0.3
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-config v0.12.0
@@ -26,6 +25,7 @@ require (
 	github.com/libp2p/go-libp2p-kad-dht v0.11.1
 	github.com/libp2p/go-libp2p-record v0.1.3
 	github.com/libp2p/go-libp2p-tls v0.1.3
+	github.com/libp2p/go-netroute v0.1.4 // indirect
 	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multihash v0.0.15
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9 h1:HD8gA2tkByhMAwYaFAX9w2l7vxvBQ5NMoxDrkhqhtn4=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
-github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIoKjsnZuH8vjyaysT/ses3EvZeaV/1UkF2M=
-github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
@@ -60,8 +58,6 @@ github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhY
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgraph-io/badger v1.6.1 h1:w9pSFNSdq/JPM1N12Fz/F/bzo993Is1W+Q7HjPzi7yg=
 github.com/dgraph-io/badger v1.6.1/go.mod h1:FRmFw3uxvcpa8zG3Rxs0th+hCLIuaQg8HlNV5bjgnuU=
-github.com/dgraph-io/badger v1.6.2 h1:mNw0qs90GVgGGWylh0umH5iag1j6n/PeJtNvL6KY/x8=
-github.com/dgraph-io/badger v1.6.2/go.mod h1:JW2yswe3V058sS0kZ2h/AXeDSqFjxnZcRrVH//y2UQE=
 github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
 github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgryski/go-farm v0.0.0-20190104051053-3adb47b1fb0f/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -181,8 +177,6 @@ github.com/ipfs/go-ds-badger v0.0.5/go.mod h1:g5AuuCGmr7efyzQhLL8MzwqcauPojGPUaH
 github.com/ipfs/go-ds-badger v0.0.7/go.mod h1:qt0/fWzZDoPW6jpQeqUjR5kBfhDNB65jd9YlmAvpQBk=
 github.com/ipfs/go-ds-badger v0.2.1/go.mod h1:Tx7l3aTph3FMFrRS838dcSJh+jjA7cX9DrGVwx/NOwE=
 github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBRn4FS6UHUk=
-github.com/ipfs/go-ds-badger v0.2.6 h1:Hy8jw4rifxtRDrqpvC1yh36oIyE37KDzsUzlHUPOFiU=
-github.com/ipfs/go-ds-badger v0.2.6/go.mod h1:02rnztVKA4aZwDuaRPTf8mpqcKmXP7mLl6JPxd14JHA=
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
 github.com/ipfs/go-ds-leveldb v0.4.1/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
@@ -535,6 +529,8 @@ github.com/libp2p/go-nat v0.0.5/go.mod h1:B7NxsVNPZmRLvMOwiEO1scOSyjA56zxYAGv1yQ
 github.com/libp2p/go-netroute v0.1.2/go.mod h1:jZLDV+1PE8y5XxBySEBgbuVAXbhtuHSdmLPL2n9MKbk=
 github.com/libp2p/go-netroute v0.1.3 h1:1ngWRx61us/EpaKkdqkMjKk/ufr/JlIFYQAxV2XX8Ig=
 github.com/libp2p/go-netroute v0.1.3/go.mod h1:jZLDV+1PE8y5XxBySEBgbuVAXbhtuHSdmLPL2n9MKbk=
+github.com/libp2p/go-netroute v0.1.4 h1:47V0+hJfYaqj1WO0A+cDkRc9xr9qKiK7i8zaoGv8Mmo=
+github.com/libp2p/go-netroute v0.1.4/go.mod h1:jZLDV+1PE8y5XxBySEBgbuVAXbhtuHSdmLPL2n9MKbk=
 github.com/libp2p/go-openssl v0.0.2/go.mod h1:v8Zw2ijCSWBQi8Pq5GAixw6DbFfa9u6VIYDXnvOXkc0=
 github.com/libp2p/go-openssl v0.0.3/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/libp2p/go-openssl v0.0.4/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=

--- a/ipfs_test.go
+++ b/ipfs_test.go
@@ -8,8 +8,6 @@ import (
 	"io/ioutil"
 	"testing"
 
-	datastore "github.com/ipfs/go-datastore"
-	dssync "github.com/ipfs/go-datastore/sync"
 	cbor "github.com/ipfs/go-ipld-cbor"
 	crypto "github.com/libp2p/go-libp2p-core/crypto"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -22,8 +20,8 @@ var secret = "2cc2c79ea52c9cc85dfd3061961dd8c4230cce0b09f182a0822c1536bf1d5f21"
 func setupPeers(t *testing.T) (p1, p2 *Peer, closer func(t *testing.T)) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	ds1 := dssync.MutexWrap(datastore.NewMapDatastore())
-	ds2 := dssync.MutexWrap(datastore.NewMapDatastore())
+	ds1 := NewInMemoryDatastore()
+	ds2 := NewInMemoryDatastore()
 	priv1, _, err := crypto.GenerateKeyPair(crypto.RSA, 2048)
 	if err != nil {
 		t.Fatal(err)

--- a/util.go
+++ b/util.go
@@ -2,13 +2,10 @@ package ipfslite
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"os/user"
 	"time"
 
-	"github.com/ipfs/go-datastore"
-	badger "github.com/ipfs/go-ds-badger"
+	datastore "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
 	config "github.com/ipfs/go-ipfs-config"
 	ipns "github.com/ipfs/go-ipns"
 	"github.com/libp2p/go-libp2p"
@@ -32,30 +29,10 @@ func DefaultBootstrapPeers() []peer.AddrInfo {
 	return defaults
 }
 
-// IPFSBadgerDatastore returns the Badger datastore used by the IPFS daemon
-// (from `~/.ipfs/datastore`). Do not use the default datastore when the
-// regular IFPS daemon is running at the same time.
-func IPFSBadgerDatastore() (datastore.Batching, error) {
-	home := os.Getenv("HOME")
-	if home == "" {
-		usr, err := user.Current()
-		if err != nil {
-			panic(fmt.Sprintf("cannot get current user: %s", err))
-		}
-		home = usr.HomeDir
-	}
-
-	path, err := config.DataStorePath(home)
-	if err != nil {
-		return nil, err
-	}
-	return BadgerDatastore(path)
-}
-
-// BadgerDatastore returns a new instance of Badger-DS persisting
-// to the given path with the default options.
-func BadgerDatastore(path string) (datastore.Batching, error) {
-	return badger.NewDatastore(path, &badger.DefaultOptions)
+// NewInMemoryDatastore provides a sync datastore that lives in-memory only
+// and is not persisted.
+func NewInMemoryDatastore() datastore.Batching {
+	return dssync.MutexWrap(datastore.NewMapDatastore())
 }
 
 // Libp2pOptionsExtra provides some useful libp2p options


### PR DESCRIPTION
This:

* Removes utility methods using Badger. It is a heavy dependency that breaks wasm compilation and not too valuable.
* Add an InMemoryDatastore helper.
* Brush-up README.md