### PR TITLE
Expose exchange from ipfs-lite

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ipfs/go-ipfs-blockstore v1.1.1
 	github.com/ipfs/go-ipfs-chunker v0.0.5
 	github.com/ipfs/go-ipfs-config v0.16.0
+	github.com/ipfs/go-ipfs-exchange-interface v0.1.0
 	github.com/ipfs/go-ipfs-exchange-offline v0.1.1
 	github.com/ipfs/go-ipfs-provider v0.7.1
 	github.com/ipfs/go-ipld-cbor v0.0.5
@@ -24,7 +25,6 @@ require (
 	github.com/libp2p/go-libp2p-core v0.11.0
 	github.com/libp2p/go-libp2p-kad-dht v0.15.0
 	github.com/libp2p/go-libp2p-record v0.1.3
-	github.com/libp2p/go-libp2p-tls v0.3.1
 	github.com/libp2p/go-tcp-transport v0.4.0
 	github.com/libp2p/go-ws-transport v0.5.0
 	github.com/multiformats/go-multiaddr v0.4.1

--- a/ipfs.go
+++ b/ipfs.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	chunker "github.com/ipfs/go-ipfs-chunker"
+	"github.com/ipfs/go-ipfs-exchange-interface"
 	offline "github.com/ipfs/go-ipfs-exchange-offline"
 	provider "github.com/ipfs/go-ipfs-provider"
 	"github.com/ipfs/go-ipfs-provider/queue"
@@ -74,6 +75,7 @@ type Peer struct {
 	store datastore.Batching
 
 	ipld.DAGService // become a DAG service
+	exch            exchange.Interface
 	bstore          blockstore.Blockstore
 	bserv           blockservice.BlockService
 	reprovider      provider.System
@@ -149,6 +151,7 @@ func (p *Peer) setupBlockService() error {
 	bswapnet := network.NewFromIpfsHost(p.host, p.dht)
 	bswap := bitswap.New(p.ctx, bswapnet, p.bstore)
 	p.bserv = blockservice.New(p.bstore, bswap)
+	p.exch = bswap
 	return nil
 }
 
@@ -328,4 +331,9 @@ func (p *Peer) BlockStore() blockstore.Blockstore {
 // a shorthand for .Blockstore().Has().
 func (p *Peer) HasBlock(ctx context.Context, c cid.Cid) (bool, error) {
 	return p.BlockStore().Has(ctx, c)
+}
+
+// Exchange returns the underlying exchange implementation
+func (p *Peer) Exchange() exchange.Interface {
+	return p.exch
 }


### PR DESCRIPTION
We initialize bitswap when we create the light client. I feel it could be useful to expose this to the users.