### PR TITLE
Support using a custom Blockstore

### DIFF
--- a/examples/litepeer/litepeer.go
+++ b/examples/litepeer/litepeer.go
@@ -39,7 +39,7 @@ func main() {
 		panic(err)
 	}
 
-	lite, err := ipfslite.New(ctx, ds, h, dht, nil)
+	lite, err := ipfslite.New(ctx, ds, nil, h, dht, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/walker/walker.go
+++ b/examples/walker/walker.go
@@ -44,7 +44,7 @@ func main() {
 		panic(err)
 	}
 
-	lite, err := ipfslite.New(ctx, ds, h, dht, nil)
+	lite, err := ipfslite.New(ctx, ds, nil, h, dht, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/ipfs_test.go
+++ b/ipfs_test.go
@@ -79,12 +79,12 @@ func setupPeers(t *testing.T) (p1, p2 *Peer, closer func(t *testing.T)) {
 			}
 		}
 	}
-	p1, err = New(ctx, ds1, h1, dht1, nil)
+	p1, err = New(ctx, ds1, nil, h1, dht1, nil)
 	if err != nil {
 		closer(t)
 		t.Fatal(err)
 	}
-	p2, err = New(ctx, ds2, h2, dht2, nil)
+	p2, err = New(ctx, ds2, nil, h2, dht2, nil)
 	if err != nil {
 		closer(t)
 		t.Fatal(err)


### PR DESCRIPTION
Usually (in Kubo), the Blockstore is just built on top of the datastore.

There are, however, blockstore implementations (i.e StoreTheHash) that are optimized blockstores and not general purpose datastores.

This commit allows providing a custom blockstore, but initializes everything as before when set to nil. The signature of New() changes accordingly. A new option UncachedBlockstore, allows disabling the CachedBlockstore-wrapping that also happens by default, since some datastores/blockstores include their own caching and bloom-filters, so this can potentially be making things slower.